### PR TITLE
ページ数表示の制御を追加

### DIFF
--- a/ronbun-j.tex
+++ b/ronbun-j.tex
@@ -15,6 +15,8 @@
 %
 \usepackage{epic,eepic,eepicsup}
 \usepackage{graphicx}
+%  ページ数を非表示にしたい方は以下をアンコメントしてください．
+% \pagestyle{empty} 
 %  amsを使う方は以下をアンコメントしてください．
 %\usepackage{amssymb,amsmath}
 % 英語はサポートしているかどうか不明


### PR DESCRIPTION
シンポジウム原稿等ではページ数を表示しないように指定されるので、`\pagestyle{empty} `を追加しました。