### PR TITLE
図・表のフォントをゴシックに

### DIFF
--- a/ronbun-j.tex
+++ b/ronbun-j.tex
@@ -101,10 +101,10 @@ It should be placed below the title and authors' names set in 12\,pt, spacing a 
 \renewcommand{\thesubsection}{{\sf(\arabic{subsection})}}
 \renewcommand{\thesubsubsection}{{\sf\alph{subsubsection})}}
 % 図表フォント
-\renewcommand{\figurename}{図\nobreak}
-\renewcommand{\tablename}{表\nobreak}
-\renewcommand{\figuresname}{図\nobreak}
-\renewcommand{\tablesname}{表\nobreak}
+\renewcommand{\figurename}{\textgt{図}\nobreak}
+\renewcommand{\tablename}{\textgt{表}\nobreak}
+\renewcommand{\figuresname}{\textgt{図}\nobreak}
+\renewcommand{\tablesname}{\textgt{表}\nobreak}
 \renewcommand{\thefigure}{{\sf-\arabic{figure}}}
 \renewcommand{\thetable}{{\sf-\arabic{table}}}
 


### PR DESCRIPTION
\figurenameや\tablesnameを用いた時に，「図」や「表」がゴシック体になるように修正しました．